### PR TITLE
Remove import which does not seem to be used any more

### DIFF
--- a/examples/todo/src/renderOnServer.js
+++ b/examples/todo/src/renderOnServer.js
@@ -3,7 +3,6 @@ import path from 'path';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import Relay from 'react-relay';
-import RelayStoreData from 'react-relay/lib/RelayStoreData';
 import {match} from 'react-router';
 import routes from './routes';
 


### PR DESCRIPTION
It seems like since we don't need ti inject batching strategy, we would not need this import?
