### PR TITLE
update `react-router-relay` to 0.13.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.3.19",
-    "react-router-relay": "0.13.1"
+    "react-router-relay": "0.13.2"
   },
   "devDependencies": {
     "babel-cli": "^6.3.17",


### PR DESCRIPTION
to support `render` callback of RelyRenderer
