### PR TITLE
Add otherMiddleware to render

### DIFF
--- a/src/prepareData.js
+++ b/src/prepareData.js
@@ -2,7 +2,7 @@ import IsomorphicRelay from 'isomorphic-relay';
 import QueryAggregator from 'react-router-relay/lib/QueryAggregator';
 import render from './render';
 
-export default function prepareData(renderProps, networkLayer, otherMiddleware) {
+export default function prepareData(renderProps, networkLayer) {
   const queryAggregator = new QueryAggregator(renderProps);
 
   return IsomorphicRelay.prepareData(
@@ -18,7 +18,6 @@ export default function prepareData(renderProps, networkLayer, otherMiddleware) 
       environment,
       initialReadyState,
       queryAggregator,
-      render: render(otherMiddleware),
     },
   }));
 }

--- a/src/prepareData.js
+++ b/src/prepareData.js
@@ -2,7 +2,7 @@ import IsomorphicRelay from 'isomorphic-relay';
 import QueryAggregator from 'react-router-relay/lib/QueryAggregator';
 import render from './render';
 
-export default function prepareData(renderProps, networkLayer) {
+export default function prepareData(renderProps, networkLayer, otherMiddleware) {
   const queryAggregator = new QueryAggregator(renderProps);
 
   return IsomorphicRelay.prepareData(
@@ -18,7 +18,7 @@ export default function prepareData(renderProps, networkLayer) {
       environment,
       initialReadyState,
       queryAggregator,
-      render,
+      render: render(otherMiddleware),
     },
   }));
 }

--- a/src/prepareInitialRender.js
+++ b/src/prepareInitialRender.js
@@ -2,7 +2,7 @@ import IsomorphicRelay from 'isomorphic-relay';
 import QueryAggregator from 'react-router-relay/lib/QueryAggregator';
 import render from './render';
 
-export default function prepareInitialRender(environment, renderProps) {
+export default function prepareInitialRender(environment, renderProps, otherMiddleware) {
   const queryAggregator = new QueryAggregator(renderProps);
 
   return IsomorphicRelay.prepareInitialRender({
@@ -14,6 +14,6 @@ export default function prepareInitialRender(environment, renderProps) {
     environment,
     initialReadyState,
     queryAggregator,
-    render,
+    render: render(otherMiddleware),
   }));
 }

--- a/src/prepareInitialRender.js
+++ b/src/prepareInitialRender.js
@@ -14,6 +14,6 @@ export default function prepareInitialRender(environment, renderProps, otherMidd
     environment,
     initialReadyState,
     queryAggregator,
-    render: render(otherMiddleware),
+    render: render(null, otherMiddleware),
   }));
 }

--- a/src/render.js
+++ b/src/render.js
@@ -3,12 +3,14 @@ import { applyRouterMiddleware } from 'react-router';
 import useRelay from 'react-router-relay';
 import IsomorphicRelayRouterContext from './IsomorphicRelayRouterContext';
 
-export default applyRouterMiddleware({
-  renderRouterContext: (child, props) => (
-    <IsomorphicRelayRouterContext {...props}>
-      {child}
-    </IsomorphicRelayRouterContext>
-  ),
+export default function(otherMiddleware = []) {
+  return applyRouterMiddleware(...otherMiddleware, {
+    renderRouterContext: (child, props) => (
+      <IsomorphicRelayRouterContext {...props}>
+        {child}
+      </IsomorphicRelayRouterContext>
+    ),
 
-  renderRouteComponent: useRelay.renderRouteComponent,
-});
+    renderRouteComponent: useRelay.renderRouteComponent,
+  });
+}

--- a/src/render.js
+++ b/src/render.js
@@ -3,8 +3,12 @@ import { applyRouterMiddleware } from 'react-router';
 import useRelay from 'react-router-relay';
 import IsomorphicRelayRouterContext from './IsomorphicRelayRouterContext';
 
-export default function(otherMiddleware = []) {
-  return applyRouterMiddleware(...otherMiddleware, {
+export default function(propsOrMiddleware = []) {
+  if (propsOrMiddleware.render) {
+    return propsOrMiddleware.render(propsOrMiddleware);
+  }
+
+  return applyRouterMiddleware(...propsOrMiddleware, {
     renderRouterContext: (child, props) => (
       <IsomorphicRelayRouterContext {...props}>
         {child}

--- a/src/render.js
+++ b/src/render.js
@@ -3,12 +3,8 @@ import { applyRouterMiddleware } from 'react-router';
 import useRelay from 'react-router-relay';
 import IsomorphicRelayRouterContext from './IsomorphicRelayRouterContext';
 
-export default function(propsOrMiddleware = []) {
-  if (propsOrMiddleware.render) {
-    return propsOrMiddleware.render(propsOrMiddleware);
-  }
-
-  return applyRouterMiddleware(...propsOrMiddleware, {
+export default function(props, otherMiddleware = []) {
+  const render = applyRouterMiddleware(...otherMiddleware, {
     renderRouterContext: (child, props) => (
       <IsomorphicRelayRouterContext {...props}>
         {child}
@@ -17,4 +13,6 @@ export default function(propsOrMiddleware = []) {
 
     renderRouteComponent: useRelay.renderRouteComponent,
   });
+
+  return (!!props) ? render(props) : render;
 }


### PR DESCRIPTION
A possible solution to using other middleware...

``` jsx
...
IsomorphicRouter.prepareData(renderProps, networkLayer, [useFoo(), useBar()]).then(render, next);
...
```

``` jsx
...
IsomorphicRouter.prepareInitialRender(environment, renderProps, [useFoo(), useBar()]).then(props => {
  ReactDOM.render(<Router {...props} />, rootElement);
});
...
```

`render` sets a default empty array, so the `otherMiddleware[]` is entirely optional. This setup would also allow using a different set of middleware for server and client rendering, if that's your thing. 
