### PR TITLE
Export useIsoRelay react-router middleware

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 import prepareData from './prepareData';
 import prepareInitialRender from './prepareInitialRender';
 import render from './render';
+import useIsoRelay from './useIsoRelay';
 
 export default {
   prepareData,
   prepareInitialRender,
   render,
+  useIsoRelay,
 };

--- a/src/prepareData.js
+++ b/src/prepareData.js
@@ -1,6 +1,5 @@
 import IsomorphicRelay from 'isomorphic-relay';
 import IsomorphicQueryAggregator from './IsomorphicQueryAggregator';
-import render from './render';
 
 export default function prepareData(renderProps, networkLayer) {
   const queryAggregator = new IsomorphicQueryAggregator(renderProps);
@@ -18,7 +17,6 @@ export default function prepareData(renderProps, networkLayer) {
       environment,
       initialReadyState,
       queryAggregator,
-      render,
     },
   }));
 }

--- a/src/render.js
+++ b/src/render.js
@@ -1,14 +1,4 @@
-import React from 'react';
 import { applyRouterMiddleware } from 'react-router';
-import useRelay from 'react-router-relay';
-import IsomorphicRelayRouterContext from './IsomorphicRelayRouterContext';
+import useIsoRelay from './useIsoRelay';
 
-export default applyRouterMiddleware({
-  renderRouterContext: (child, props) => (
-    <IsomorphicRelayRouterContext {...props}>
-      {child}
-    </IsomorphicRelayRouterContext>
-  ),
-
-  renderRouteComponent: useRelay.renderRouteComponent,
-});
+export default applyRouterMiddleware(useIsoRelay);

--- a/src/useIsoRelay.js
+++ b/src/useIsoRelay.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import useRelay from 'react-router-relay';
+import IsomorphicRelayRouterContext from './IsomorphicRelayRouterContext';
+
+export default {
+  renderRouterContext: (child, props) => (
+    <IsomorphicRelayRouterContext {...props}>
+      {child}
+    </IsomorphicRelayRouterContext>
+  ),
+
+  renderRouteComponent: useRelay.renderRouteComponent,
+};


### PR DESCRIPTION
This PR opens access to react-router's applyRouterMiddleware API in order to make the route render callback configurable for both client and server side respectively 
(i.e. be able to add to / replace the new useIsoRelay middleware with client/server side specific middlewares).

@denvned Please review & if you decide to go with this, I'll happily rename the render.js to something better fitting. The term rendering to me seems overly used in the react world anyway.

Fixes #30
