### PR TITLE
Update react-router peer dependency version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   "peerDependencies": {
     "isomorphic-relay": "^0.7.3",
     "react": "^15.0.1",
-    "react-router": "^2.3.0"
+    "react-router": ">=2.3.0 <4"
   }
 }


### PR DESCRIPTION
As this repo only uses `applyRouterMiddleware` directly from react-router, there should be no issue depending on version 3.x.x of react-router. Fix #57