### PR TITLE
React 16: Upgrade react-router-relay dep to 0.13.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.3.19",
-    "react-router-relay": "0.13.5"
+    "react-router-relay": "0.13.8"
   },
   "devDependencies": {
     "babel-cli": "^6.3.17",


### PR DESCRIPTION
React 16 drops `React.PropTypes`. `prop-types` was added to RRR here: https://github.com/relay-tools/react-router-relay/commit/d348571f6864d19b0cd1b36173ea5992828c5d40